### PR TITLE
keyword arguments conform to PEP8

### DIFF
--- a/core/data/catseverywhere.py
+++ b/core/data/catseverywhere.py
@@ -11,7 +11,7 @@ email_addresses = []
 def hello_world():
     return render_template('index.html')
 
-@app.route('/signup', methods = ['POST'])
+@app.route('/signup', methods=['POST'])
 def signup():
     email = request.form['email']
     email_addresses.append(email)
@@ -20,7 +20,7 @@ def signup():
 
 @app.route('/emails.html')
 def emails():
-    return render_template('emails.html', email_addresses = email_addresses)
+    return render_template('emails.html', email_addresses=email_addresses)
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))


### PR DESCRIPTION
> Don't use spaces around the = sign when used to indicate a keyword argument or a default parameter value.

http://legacy.python.org/dev/peps/pep-0008/#id19
